### PR TITLE
Gas optimization

### DIFF
--- a/src/lock.sol
+++ b/src/lock.sol
@@ -2,13 +2,12 @@
 pragma solidity ^0.8.6;
 
 contract Lock {
-    bool unlocked = true;
+    uint unlocked = 1;
 
     modifier lock() {
         require(unlocked, "lock/locked");
-        unlocked = false;
+        unlocked = 0;
         _;
-        unlocked = true;
+        unlocked = 1;
     }
 }
-


### PR DESCRIPTION
"Under the hood of solidity, Booleans (bool) are uint8 which means they use 8 bits of storage. A Boolean can only have two values: True or False. This means that you can store a boolean in only a single bit." So I adjusted "unlocked" to uint256 to save some gas :)